### PR TITLE
Update Ubuntu runner labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build-health:
     name: Build health
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: read
@@ -57,7 +57,7 @@ jobs:
 
   actionlint:
     name: Lint GitHub Actions
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   packages:
     name: Packages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: write # Required for creating release
@@ -57,7 +57,7 @@ jobs:
 
   documentation:
     name: Documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     environment:
       name: github-pages


### PR DESCRIPTION
Update GitHub Actions workflows to ubuntu-26.04 and whitelist the label for actionlint.